### PR TITLE
Fix flaky tests in `DatabaseFieldConfigTest`

### DIFF
--- a/src/test/java/com/j256/ormlite/field/DatabaseFieldConfigTest.java
+++ b/src/test/java/com/j256/ormlite/field/DatabaseFieldConfigTest.java
@@ -82,9 +82,17 @@ public class DatabaseFieldConfigTest extends BaseCoreTest {
 		assertTrue(config.isUseGetSet());
 	}
 
+	public static Field[] getDeclaredFieldsWithNames(Class clazz, String... names) throws Exception {
+		Field[] fields = new Field[names.length];
+		for (int i = 0; i < names.length; i++) {
+			fields[i] = clazz.getDeclaredField(names[i]);
+		}
+		return fields;
+	}
+
 	@Test
 	public void testFromDbField() throws Exception {
-		Field[] fields = Foo.class.getDeclaredFields();
+		Field[] fields = getDeclaredFieldsWithNames(Foo.class, "field");
 		assertTrue(fields.length >= 1);
 		DatabaseFieldConfig config = DatabaseFieldConfig.fromField(databaseType, "foo", fields[0]);
 		assertNotNull(config);
@@ -97,7 +105,7 @@ public class DatabaseFieldConfigTest extends BaseCoreTest {
 
 	@Test
 	public void testJavaxAnnotations() throws Exception {
-		Field[] fields = JavaxAnno.class.getDeclaredFields();
+		Field[] fields = getDeclaredFieldsWithNames(JavaxAnno.class, "notColumn", "id", "stuff", "length", "nullable", "foo", "foo2");
 		assertTrue(fields.length >= 7);
 
 		// not a column
@@ -142,7 +150,7 @@ public class DatabaseFieldConfigTest extends BaseCoreTest {
 
 	@Test
 	public void testJavaxJustId() throws Exception {
-		Field[] fields = JavaxAnnoJustId.class.getDeclaredFields();
+		Field[] fields = getDeclaredFieldsWithNames(JavaxAnnoJustId.class, "id");
 		assertTrue(fields.length >= 1);
 
 		DatabaseFieldConfig config = DatabaseFieldConfig.fromField(databaseType, "foo", fields[0]);
@@ -155,7 +163,7 @@ public class DatabaseFieldConfigTest extends BaseCoreTest {
 
 	@Test
 	public void testJavaxGetSet() throws Exception {
-		Field[] fields = JavaxGetSet.class.getDeclaredFields();
+		Field[] fields = getDeclaredFieldsWithNames(JavaxGetSet.class, "id");
 		assertTrue(fields.length >= 1);
 
 		DatabaseFieldConfig config = DatabaseFieldConfig.fromField(databaseType, "foo", fields[0]);
@@ -166,7 +174,7 @@ public class DatabaseFieldConfigTest extends BaseCoreTest {
 
 	@Test
 	public void testJavaxUnique() throws Exception {
-		Field[] fields = JavaxUnique.class.getDeclaredFields();
+		Field[] fields = getDeclaredFieldsWithNames(JavaxUnique.class, "id");
 		assertTrue(fields.length >= 1);
 
 		DatabaseFieldConfig config = DatabaseFieldConfig.fromField(databaseType, "foo", fields[0]);
@@ -177,7 +185,7 @@ public class DatabaseFieldConfigTest extends BaseCoreTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testUnknownEnumVal() throws Exception {
-		Field[] fields = BadUnknownVal.class.getDeclaredFields();
+		Field[] fields = getDeclaredFieldsWithNames(BadUnknownVal.class, "ourEnum");
 		assertTrue(fields.length >= 1);
 		DatabaseFieldConfig.fromField(databaseType, "foo", fields[0]);
 	}
@@ -193,7 +201,7 @@ public class DatabaseFieldConfigTest extends BaseCoreTest {
 
 	@Test
 	public void testComboIndex() throws Exception {
-		Field[] fields = ComboIndex.class.getDeclaredFields();
+		Field[] fields = getDeclaredFieldsWithNames(ComboIndex.class, "stuff", "junk");
 		assertTrue(fields.length >= 2);
 		DatabaseFieldConfig fieldConfig = DatabaseFieldConfig.fromField(databaseType, "foo", fields[0]);
 		String tableName = "foo";


### PR DESCRIPTION
Several flaky tests are found in this project and this PR proposes to fix them.

1. How to reproduce the flaky test
- The project is built and tested under `javaJDK8`.
- The tool used for the flaky test detection is [NonDex](https://github.com/TestingResearchIllinois/NonDex).
- I ran `mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=DatabaseFieldConfigTest`, which produced
> [ERROR] Failures: 
> [ERROR]   DatabaseFieldConfigTest.testFromDbField:90
> [ERROR]   DatabaseFieldConfigTest.testJavaxAnnotations:104 expected null, but was:<com.j256.ormlite.field.DatabaseFieldConfig@51565ec2>
> [ERROR]   DatabaseFieldConfigTest.testJavaxGetSet:162
> [ERROR]   DatabaseFieldConfigTest.testJavaxJustId:149
> [ERROR]   DatabaseFieldConfigTest.testJavaxUnique:173
> [ERROR] Errors: 
> [ERROR]   DatabaseFieldConfigTest.testComboIndex:200 NullPointer
and 
> [ERROR] Failures: 
> [ERROR]   DatabaseFieldConfigTest.testJavaxAnnotations:104 expected null, but was:<com.j256.ormlite.field.DatabaseFieldConfig@2a5ca609>
> [ERROR]   DatabaseFieldConfigTest.testJavaxGetSet:162
> [ERROR]   DatabaseFieldConfigTest.testUnknownEnumVal Expected exception: java.lang.IllegalArgumentException

2. Why the tests failed
- The tests failed for similar reasons. In the failed tests, the method `Class.getDeclaredFields` is used to get all the fields declared by some classes, and fixed indexes are used to get certain fields from the `Field[]` returned by the method. However, according to the [documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--), the order of elements in the array is unpredictable.

3. The changes made
- New method `getDeclaredFieldsWithNames` is defined to get the declared fields with the specific names to guarantee the order of elements in the array.